### PR TITLE
Fix navbar directory case-sensitivity

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,7 @@
 import { Box } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
-import { Navbar } from './components/navBar/NavBar';
+import { Navbar } from './components/navbar/NavBar';
 import { ScrollToTop } from './components/util/ScrollToTop';
 import { CLIENT_ROUTES } from './constants';
 import { AuthCallback } from './pages/AuthCallback';


### PR DESCRIPTION
## Problem
The frontend build is still failing in CI with module resolution error:
```
Cannot find module './components/navBar/NavBar'
```

## Root Cause
The import path uses `navBar` (camelCase) but the actual directory is `navbar` (all lowercase).

## Solution
Changed the import in `App.tsx` from:
```typescript
import { Navbar } from './components/navBar/NavBar';
```

to:
```typescript
import { Navbar } from './components/navbar/NavBar';
```

## Files Changed
- `client/src/App.tsx`

This completes the case-sensitivity fixes for the CI build.