### PR TITLE
Revert NavbarSearch to Original Implementation

### DIFF
--- a/client/src/components/navbar/NavbarSearch.tsx
+++ b/client/src/components/navbar/NavbarSearch.tsx
@@ -3,13 +3,12 @@ import {
 	Flex,
 	Input,
 	InputGroup,
-	Menu,
 	Skeleton,
 	Stack,
 	Text,
 } from '@chakra-ui/react';
 import { AnimatePresence, motion } from 'framer-motion';
-import { JSX, useEffect, useState } from 'react';
+import { JSX, useEffect, useRef, useState } from 'react';
 import { FaSearch, FaShop } from 'react-icons/fa';
 import { MdCancel, MdCategory } from 'react-icons/md';
 import { RiStackFill } from 'react-icons/ri';
@@ -20,19 +19,23 @@ import { SearchResult, SearchResultCollection } from '@common/types/SearchResult
 import { CLIENT_ROUTES } from '../../constants';
 import useApi from '../../hooks/useApi';
 
+const MotionBox = motion.create(Box);
+
 export const NavbarSearch = () => {
 	const navigate = useNavigate();
 	const { getPublicResource } = useApi();
+
+	const searchContainerRef = useRef<HTMLDivElement>(null);
 
 	const [searchQuery, setSearchQuery] = useState('');
 	const [searchResultCollection, setSearchResultCollection] =
 		useState<SearchResultCollection | null>(null);
 	const [searchResultsLoading, setSearchResultsLoading] = useState<boolean>(false);
 	const [searchError, setSearchError] = useState<boolean>(false);
-	const [isOpen, setIsOpen] = useState(false);
+	const [showSearchPopover, setShowSearchPopover] = useState(false);
 
 	const search = async (query: string) => {
-		const { data, error } = await getPublicResource(
+		const { data, error} = await getPublicResource(
 			`${API_ROUTES.search.base}?${API_ROUTES.search.queryParam}=${encodeURIComponent(query)}`,
 		);
 		if (data) {
@@ -47,14 +50,14 @@ export const NavbarSearch = () => {
 	};
 
 	useEffect(() => {
-		setIsOpen(false);
+		setShowSearchPopover(false);
+
 		setSearchResultCollection(null);
-		
 		if (searchQuery?.length < SEARCH_QUERY_LIMITS.minChars) {
 			return;
 		}
 
-		setIsOpen(true);
+		setShowSearchPopover(true);
 		setSearchError(false);
 		setSearchResultsLoading(true);
 
@@ -64,6 +67,30 @@ export const NavbarSearch = () => {
 
 		return () => clearTimeout(timer);
 	}, [searchQuery]);
+
+	useEffect(() => {
+		const handleClickOutside = (e: MouseEvent) => {
+			if (
+				searchContainerRef.current &&
+				!searchContainerRef.current.contains(e.target as Node)
+			) {
+				setShowSearchPopover(false);
+			}
+		};
+
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') {
+				setShowSearchPopover(false);
+			}
+		};
+
+		document.addEventListener('mousedown', handleClickOutside);
+		document.addEventListener('keydown', handleKeyDown);
+		return () => {
+			document.removeEventListener('mousedown', handleClickOutside);
+			document.removeEventListener('keydown', handleKeyDown);
+		};
+	}, []);
 
 	const renderSearchResultGroupLabel = (icon: JSX.Element, label: string) => (
 		<Flex mx={3} my={1} alignItems="center" gap={2}>
@@ -76,22 +103,22 @@ export const NavbarSearch = () => {
 
 	const renderSearchResults = (results: SearchResult[], path: string) =>
 		results.map((result) => (
-			<Menu.Item
+			<Box
 				key={result.id}
-				value={result.id}
-				onClick={() => {
-					navigate(`/${path}/${result.id}`);
-					setSearchQuery('');
-					setSearchResultCollection(null);
-					setIsOpen(false);
-				}}
-				cursor="pointer"
-				fontSize={16}
 				p={1}
 				pl={9}
+				cursor="pointer"
+				_hover={{ bg: 'gray.100' }}
+				onClick={() => {
+					navigate(`/${path}/${result.id}`);
+
+					setSearchQuery('');
+					setSearchResultCollection(null);
+					setShowSearchPopover(false);
+				}}
 			>
-				{result.label}
-			</Menu.Item>
+				<Text fontSize={16}>{result.label}</Text>
+			</Box>
 		));
 
 	const renderSearchException = (message: string) => (
@@ -101,87 +128,101 @@ export const NavbarSearch = () => {
 	);
 
 	return (
-		<Menu.Root open={isOpen} onOpenChange={(e) => setIsOpen(e.open)}>
-			<Menu.Trigger asChild>
-				<Box position="relative" width="100%">
-					<InputGroup
-						width="100%"
-						startElement={<FaSearch size={16} />}
-						endElement={
-							<AnimatePresence>
-								{searchQuery && (
-									<motion.div
-										initial={{ opacity: 0 }}
-										animate={{ opacity: 1 }}
-										exit={{ opacity: 0 }}
-										transition={{ duration: 0.15 }}
-										style={{ display: 'flex', cursor: 'pointer' }}
-										onClick={() => setSearchQuery('')}
-									>
-										<MdCancel size={18} />
-									</motion.div>
-								)}
-							</AnimatePresence>
-						}
-						py={1}
+		<Box ref={searchContainerRef} position="relative" width="100%">
+			<InputGroup
+				width="100%"
+				startElement={<FaSearch size={16} />}
+				endElement={
+					<AnimatePresence>
+						{searchQuery && (
+							<motion.div
+								initial={{ opacity: 0 }}
+								animate={{ opacity: 1 }}
+								exit={{ opacity: 0 }}
+								transition={{ duration: 0.15 }}
+								style={{ display: 'flex', cursor: 'pointer' }}
+								onClick={() => setSearchQuery('')}
+							>
+								<MdCancel size={18} />
+							</motion.div>
+						)}
+					</AnimatePresence>
+				}
+				py={1}
+			>
+				<Input
+					maxLength={SEARCH_QUERY_LIMITS.maxChars}
+					fontSize={16}
+					placeholder="Search..."
+					bg="#FFF"
+					style={{ borderRadius: 20 }}
+					value={searchQuery}
+					onChange={(e) => setSearchQuery(e.target.value)}
+					onFocus={() => searchResultCollection && setShowSearchPopover(true)}
+				/>
+			</InputGroup>
+			<AnimatePresence>
+				{showSearchPopover && searchQuery && (
+					<MotionBox
+						initial={{ opacity: 0 }}
+						animate={{ opacity: 1 }}
+						exit={{ opacity: 0 }}
+						transition={{ duration: 0.15 }}
+						position="absolute"
+						top="100%"
+						left={0}
+						right={0}
+						mt={1}
+						bg="#FFF"
+						borderRadius="md"
+						boxShadow="md"
+						overflow="hidden"
+						zIndex="popover"
 					>
-						<Input
-							maxLength={SEARCH_QUERY_LIMITS.maxChars}
-							fontSize={16}
-							placeholder="Search..."
-							bg="#FFF"
-							style={{ borderRadius: 20 }}
-							value={searchQuery}
-							onChange={(e) => setSearchQuery(e.target.value)}
-						/>
-					</InputGroup>
-				</Box>
-			</Menu.Trigger>
-			<Menu.Positioner>
-				<Menu.Content boxShadow="md" borderRadius="md" minW="550px">
-					<Stack gap={0} my={2}>
-						{searchResultsLoading && (
-							<Stack gap={2} px={2}>
-								<Skeleton width="55%" height={6}></Skeleton>
-								<Skeleton width="70%" height={6}></Skeleton>
-								<Skeleton width="35%" height={6}></Skeleton>
-							</Stack>
-						)}
-						{searchError && renderSearchException('An error occurred')}
-						{searchResultCollection && (
-							<>
-								{[
-									searchResultCollection.categoryResults,
-									searchResultCollection.listingResults,
-									searchResultCollection.shopResults,
-								].every((resultList) => resultList.length === 0) &&
-									renderSearchException('No results found')}
+						<Stack gap={0} my={2}>
+							{searchResultsLoading && (
+								<Stack gap={2} px={2}>
+									<Skeleton width="55%" height={6}></Skeleton>
+									<Skeleton width="70%" height={6}></Skeleton>
+									<Skeleton width="35%" height={6}></Skeleton>
+								</Stack>
+							)}
+							{searchError && renderSearchException('An error occurred')}
+							{searchResultCollection && (
+								<>
+									{[
+										searchResultCollection.categoryResults,
+										searchResultCollection.listingResults,
+										searchResultCollection.shopResults,
+									].every((resultList) => resultList.length === 0) &&
+										renderSearchException('No results found')}
 
-								{searchResultCollection.categoryResults.length > 0 &&
-									renderSearchResultGroupLabel(<MdCategory />, 'Categories')}
-								{renderSearchResults(
-									searchResultCollection.categoryResults,
-									CLIENT_ROUTES.category,
-								)}
+									{searchResultCollection.categoryResults.length > 0 &&
+										renderSearchResultGroupLabel(<MdCategory />, 'Categories')}
+									{renderSearchResults(
+										searchResultCollection.categoryResults,
+										CLIENT_ROUTES.category,
+									)}
 
-								{searchResultCollection.shopResults.length > 0 &&
-									renderSearchResultGroupLabel(<FaShop />, 'Makers')}
-								{renderSearchResults(
-									searchResultCollection.shopResults,
-									CLIENT_ROUTES.shop,
-								)}
+									{searchResultCollection.shopResults.length > 0 &&
+										renderSearchResultGroupLabel(<FaShop />, 'Makers')}
+									{renderSearchResults(
+										searchResultCollection.shopResults,
+										CLIENT_ROUTES.shop,
+									)}
 
-								{searchResultCollection.listingResults.length > 0 &&
-									renderSearchResultGroupLabel(<RiStackFill />, 'Listings')}
-								{renderSearchResults(
-									searchResultCollection.listingResults,
-									CLIENT_ROUTES.listing,
-								)}
-							</>
-						)}
-					</Stack>
-				</Menu.Content>
-			</Menu.Positioner>
-		</Menu.Root>
+									{searchResultCollection.listingResults.length > 0 &&
+										renderSearchResultGroupLabel(<RiStackFill />, 'Listings')}
+									{renderSearchResults(
+										searchResultCollection.listingResults,
+										CLIENT_ROUTES.listing,
+									)}
+								</>
+							)}
+						</Stack>
+					</MotionBox>
+				)}
+			</AnimatePresence>
+		</Box>
 	);
 };


### PR DESCRIPTION
## Overview

Reverts `NavbarSearch` back to the original custom MotionBox dropdown implementation that was used before the component split.

## Changes

### Reverted NavbarSearch Implementation

**Modified:** `client/src/components/navbar/NavbarSearch.tsx`

**Restored original features:**
- Custom `MotionBox` dropdown with manual positioning
- Click-outside detection with `searchContainerRef` and event listeners
- Escape key handling with event listeners  
- Manual open/close state management with `showSearchPopover`
- Box components with `_hover` states for search results (not Menu.Item)
- `onFocus` handler to reopen popover when refocusing with existing results

**What was removed (Chakra Menu approach):**
- Menu.Root/Menu.Trigger/Menu.Content pattern
- Menu.Item components for results
- Chakra-controlled open state

This is the **exact same implementation** that existed when search was part of NavBar.tsx in PR #11, just as a standalone component.

## Why This Change

The Chakra Menu implementation introduced behavioral issues. This reverts to the proven original implementation that was working correctly.

## Technical Details

**Dropdown structure:**
```tsx
<Box ref={searchContainerRef} position="relative" width="100%">
  <InputGroup>...</InputGroup>
  <AnimatePresence>
    {showSearchPopover && searchQuery && (
      <MotionBox
        position="absolute"
        top="100%"
        // ... styling
      >
        <Stack>
          {/* Search results as Box components */}
        </Stack>
      </MotionBox>
    )}
  </AnimatePresence>
</Box>
```

## Testing Checklist

- [ ] Search dropdown opens when typing (min 2 chars)
- [ ] Search results appear correctly
- [ ] Clicking a result navigates and closes dropdown
- [ ] Clicking outside closes dropdown
- [ ] Escape key closes dropdown
- [ ] Clear button (X) works and clears query
- [ ] Hover states work on results
- [ ] Refocusing input with existing results reopens dropdown
- [ ] No console errors