### PR TITLE
Add Automatic Token Refresh to useApi Hook

### DIFF
--- a/client/src/hooks/useApi.ts
+++ b/client/src/hooks/useApi.ts
@@ -1,33 +1,89 @@
 import { useAuth0 } from '@auth0/auth0-react';
 import axios, { AxiosRequestConfig } from 'axios';
 
-const callApi = async (config: AxiosRequestConfig) => {
-	try {
-		const response = await axios(config);
-		const { data } = response;
+const apiServerUrl = process.env.REACT_APP_API_SERVER_URL;
 
-		return {
-			data,
-			error: null,
-		};
-	} catch (error: unknown) {
-		if (axios.isAxiosError(error)) {
-			const axiosError = error;
+const useApi = () => {
+	const { getAccessTokenSilently, loginWithRedirect } = useAuth0();
 
-			const { response } = axiosError;
+	const callApi = async (config: AxiosRequestConfig, retryCount = 0): Promise<{ data: any; error: any }> => {
+		try {
+			const response = await axios(config);
+			const { data } = response;
 
-			let message = 'http request failed';
+			return {
+				data,
+				error: null,
+			};
+		} catch (error: unknown) {
+			if (axios.isAxiosError(error)) {
+				const axiosError = error;
+				const { response } = axiosError;
 
-			if (response && response.statusText) {
-				message = response.statusText;
+				// Handle 401 - attempt token refresh
+				if (response?.status === 401 && retryCount === 0) {
+					try {
+						// Attempt to refresh the token silently
+						const newToken = await getAccessTokenSilently({
+							cacheMode: 'off', // Force refresh
+						});
+
+						// Retry the request with the new token
+						const retryConfig = {
+							...config,
+							headers: {
+								...config.headers,
+								Authorization: `Bearer ${newToken}`,
+							},
+						};
+
+						// Recursive call with retryCount = 1 to prevent infinite loops
+						return await callApi(retryConfig, 1);
+					} catch (refreshError) {
+						// Token refresh failed - redirect to login with return URL
+						const currentPath = window.location.pathname + window.location.search;
+						await loginWithRedirect({
+							appState: { returnTo: currentPath },
+						});
+
+						return {
+							data: null,
+							error: {
+								message: 'Authentication required. Redirecting to login...',
+							},
+						};
+					}
+				}
+
+				// Handle other errors
+				let message = 'http request failed';
+
+				if (response && response.statusText) {
+					message = response.statusText;
+				}
+
+				if (axiosError.message) {
+					message = axiosError.message;
+				}
+
+				if (response && response.data && response.data.message) {
+					message = response.data.message;
+				}
+
+				return {
+					data: null,
+					error: {
+						message,
+					},
+				};
 			}
 
-			if (axiosError.message) {
-				message = axiosError.message;
+			let message = 'unknown error';
+			if (error instanceof Error) {
+				message = error.message;
 			}
-
-			if (response && response.data && response.data.message) {
-				message = response.data.message;
+			if (typeof error === 'string') {
+				message = error;
 			}
 
 			return {
@@ -37,28 +93,7 @@ const callApi = async (config: AxiosRequestConfig) => {
 				},
 			};
 		}
-
-		let message = 'unknown error';
-		if (error instanceof Error) {
-			message = error.message;
-		}
-		if (typeof error === 'string') {
-			message = error;
-		}
-
-		return {
-			data: null,
-			error: {
-				message,
-			},
-		};
-	}
-};
-
-const apiServerUrl = process.env.REACT_APP_API_SERVER_URL;
-
-const useApi = () => {
-	const { getIdTokenClaims } = useAuth0();
+	};
 
 	const getPublicResource = async (endpoint: string) => {
 		const config = {
@@ -78,13 +113,8 @@ const useApi = () => {
 	};
 
 	const getToken = async () => {
-		const claims = await getIdTokenClaims();
-
-		if (!claims) {
-			throw new Error('No ID token claims found');
-		}
-
-		return claims.__raw;
+		const token = await getAccessTokenSilently();
+		return token;
 	};
 
 	const getProtectedResource = async (endpoint: string) => {


### PR DESCRIPTION
## Overview

Adds automatic JWT token refresh and re-authentication handling directly within the existing `useApi` hook. No new components, no interceptors, no additional setup required.

## Problem Solved

When a user's JWT token expires during an active session:
- API requests fail with 401 errors
- Users have to manually log out and back in
- Users lose their current page context

## Solution

This implementation works **within your existing `useApi` pattern**:

1. ✅ **Detects 401 errors** in the `callApi` function
2. ✅ **Attempts silent token refresh** using Auth0's `getAccessTokenSilently`
3. ✅ **Retries the original request** with the new token
4. ✅ **Redirects to login** if refresh fails (with return URL)
5. ✅ **Works with existing `Auth0ProviderWithNavigate`** - no changes needed

## Changes Made

### Updated `client/src/hooks/useApi.ts`

#### 1. Changed Token Method
```tsx
// Before
const { getIdTokenClaims } = useAuth0();
const token = (await getIdTokenClaims()).__raw;

// After  
const { getAccessTokenSilently, loginWithRedirect } = useAuth0();
const token = await getAccessTokenSilently();
```

**Why:** `getAccessTokenSilently()` properly handles token refresh, whereas `getIdTokenClaims()` does not.

#### 2. Added 401 Handling in `callApi`
```tsx
const callApi = async (config: AxiosRequestConfig, retryCount = 0) => {
  try {
    // Make request
  } catch (error) {
    // If 401 and first attempt
    if (response?.status === 401 && retryCount === 0) {
      try {
        // Attempt silent refresh
        const newToken = await getAccessTokenSilently({ cacheMode: 'off' });
        
        // Retry with new token
        const retryConfig = { ...config, headers: { ...config.headers, Authorization: `Bearer ${newToken}` }};
        return await callApi(retryConfig, 1);
      } catch (refreshError) {
        // Redirect to login with return URL
        const currentPath = window.location.pathname + window.location.search;
        await loginWithRedirect({ appState: { returnTo: currentPath } });
      }
    }
    // ... existing error handling
  }
};
```

**Key features:**
- `retryCount` parameter prevents infinite retry loops
- Only attempts refresh once per request
- Preserves current page URL for post-login redirect
- Falls back to existing error handling for non-401 errors

#### 3. Simplified `getToken`
```tsx
const getToken = async () => {
  const token = await getAccessTokenSilently();
  return token;
};
```

No breaking changes - just uses the proper Auth0 method.

## How It Works

### Token Refresh Flow
1. User makes API request via `useApi` methods
2. Request gets 401 Unauthorized
3. `callApi` catches the error
4. Calls `getAccessTokenSilently({ cacheMode: 'off' })` to force refresh
5. Retries original request with new token
6. User never notices the token expired

### Re-authentication Flow
1. If token refresh fails (refresh token also expired)
2. Saves current page: `window.location.pathname + window.location.search`
3. Redirects to Auth0 login: `loginWithRedirect({ appState: { returnTo: currentPath } })`
4. After login, `Auth0ProviderWithNavigate.onRedirectCallback` returns user to saved page

### Why This Works With Your Existing Code

Your `Auth0ProviderWithNavigate` already has:
```tsx
const onRedirectCallback = (appState?: AppState) => {
  navigate(appState?.returnTo || window.location.pathname);
};
```

So the `returnTo` parameter from `loginWithRedirect` automatically works! ✅

## Benefits

✅ **Zero additional setup** - works immediately after merge
✅ **No new components** - pure `useApi` enhancement
✅ **No breaking changes** - same API surface
✅ **Seamless UX** - users stay on their page
✅ **Automatic retry** - failed requests retry with new token
✅ **Single retry** - `retryCount` prevents infinite loops

## No Changes Required

- ❌ No new providers to add
- ❌ No App.tsx updates
- ❌ No component changes
- ❌ No additional configuration

Just merge and it works!

## Testing

### Test Silent Refresh
1. Log in to the app
2. In DevTools → Application → Local Storage, clear Auth0 tokens
3. Trigger any API call (like loading saved listings)
4. Verify request succeeds after automatic refresh

### Test Re-authentication
1. Navigate to a specific page (e.g., `/shop/abc123`)
2. Clear tokens and wait for them to fully expire
3. Trigger an API call
4. Verify redirect to login
5. After login, verify return to `/shop/abc123`

### Test Retry Prevention
1. Force a 401 on a request
2. Make refresh also fail
3. Verify only ONE redirect attempt (no infinite loop)

## Environment

No new environment variables needed. Uses existing Auth0 config.

## Comparison to Previous Approach

| Aspect | Interceptor Approach ❌ | This Approach ✅ |
|--------|------------------------|------------------|
| New files | 3 new files | 0 new files |
| Setup required | Provider wrapper | None |
| API changes | Replace all axios calls | None |
| Fits codebase | No | Yes |
| Works with useApi | No | Yes |
| Breaking changes | Yes | No |

## Notes

- Uses `getAccessTokenSilently` which is the proper Auth0 method for token management
- `retryCount` parameter ensures we only attempt refresh once
- Existing error handling preserved for all non-401 errors
- Works with all existing `useApi` methods: `getProtectedResource`, `postResource`, `deleteResource`
- Public resources (`getPublicResource`) unaffected