### PR TITLE
Convert CategoryTile to Proper Link Component

### DIFF
--- a/client/src/components/compositeDisplay/CategoryTile.tsx
+++ b/client/src/components/compositeDisplay/CategoryTile.tsx
@@ -1,19 +1,20 @@
 import { Box, Flex, Heading } from '@chakra-ui/react';
 import { CategoryTileData } from '@common/types/CategoryTileData';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { STANDARD_IMAGE_ASPECT_RATIO } from '../../constants';
 import { AppImage } from '../imageDisplay/AppImage';
 
 export const CategoryTile = (props: CategoryTileData) => {
-	const navigate = useNavigate();
-
 	return (
 		<Box
-			onClick={() => navigate(`/category/${props.id.toLowerCase()}`)}
+			as={Link}
+			to={`/category/${props.id.toLowerCase()}`}
 			position="relative"
 			cursor="pointer"
 			width="100%"
 			aspectRatio={STANDARD_IMAGE_ASPECT_RATIO}
+			display="block"
+			textDecoration="none"
 		>
 			<AppImage
 				imageProps={{


### PR DESCRIPTION
## Overview

Converts `CategoryTile` from a clickable `Box` to a proper React Router `Link` component, enabling native browser link features while maintaining React Router navigation.

## Changes

### Before
```tsx
const navigate = useNavigate();

return (
  <Box
    onClick={() => navigate(`/category/${props.id.toLowerCase()}`)}
    cursor="pointer"
    // ...
  >
);
```

### After
```tsx
return (
  <Box
    as={Link}
    to={`/category/${props.id.toLowerCase()}`}
    cursor="pointer"
    display="block"
    textDecoration="none"
    // ...
  >
);
```

## Benefits

✅ **Right-click → Copy Link** - Users can copy the category URL
✅ **Open in new tab** - Ctrl/Cmd+Click or middle-click to open in new tab
✅ **Hover shows URL** - Browser displays destination in status bar
✅ **SEO friendly** - Proper `<a>` tags with `href` attributes
✅ **Still uses React Router** - No page reload, maintains SPA navigation
✅ **Accessibility** - Screen readers recognize it as a link

## Technical Details

- Uses `as={Link}` to render Box as a Link component
- `to` prop replaces `onClick` + `navigate()`
- Added `display="block"` to maintain block-level layout
- Added `textDecoration="none"` to remove default link underline
- Removed `useNavigate` hook (no longer needed)

## Testing

- [ ] Click on category tile - navigates correctly (React Router)
- [ ] Right-click → "Copy link" - copies correct URL
- [ ] Middle-click - opens in new tab
- [ ] Ctrl/Cmd+Click - opens in new tab
- [ ] Hover - shows URL in browser status bar
- [ ] Visual styling unchanged
- [ ] No page reload on navigation