### PR TITLE
Fix Cart Being Cleared on Page Reload

### DIFF
--- a/client/src/providers/CartProvider.tsx
+++ b/client/src/providers/CartProvider.tsx
@@ -133,8 +133,17 @@ export const CartProvider = ({ children }: { children: ReactNode }) => {
 					`${API_ROUTES.cart.listings}?ids=${listingIds.join(',')}`,
 				);
 
+				// If API call fails, keep existing cart
 				if (error || !data) {
 					console.error('Error refreshing cart:', error);
+					return;
+				}
+
+				// If API returns empty array, it means the endpoint returned no listings
+				// This shouldn't happen if listings exist, so likely an API issue
+				// Keep existing cart instead of clearing it
+				if (!Array.isArray(data) || data.length === 0) {
+					console.warn('Cart refresh returned no listings, keeping existing cart');
 					return;
 				}
 


### PR DESCRIPTION
## Bug

Cart items were disappearing on page reload. Items would be added successfully, but refreshing the page would clear the entire cart.

## Root Cause

The `useEffect` in CartProvider was calling the cart refresh API on mount. If the API returned an **empty array** (instead of an error), the code treated it as valid data and cleared the cart.

### The Problem Flow:

1. User adds items to cart → localStorage updated ✅
2. User refreshes page → cart loads from localStorage ✅
3. CartProvider mounts → useEffect runs
4. API called: `GET /api/cart/listings?ids=abc123,def456`
5. **IF** API returns `[]` (empty array):
   - `!data` evaluates to `false` (empty arrays are truthy in JS)
   - Code continues to process the empty array
   - `buildFreshListingsMap([])` creates empty map
   - All cart items fail validation (no listings in map)
   - `setCart([])` called → **cart cleared** ❌

### Why API Might Return Empty Array:

- Backend endpoint not deployed yet
- Backend returns 200 with empty array for unknown listing IDs
- Database query issue
- Any other API issue that returns valid JSON `[]` instead of error

## Fix

Added defensive check for empty array response:

```tsx
// If API returns empty array, keep existing cart
if (!Array.isArray(data) || data.length === 0) {
  console.warn('Cart refresh returned no listings, keeping existing cart');
  return;
}
```

### New Flow:

1. User adds items to cart → localStorage updated ✅
2. User refreshes page → cart loads from localStorage ✅
3. CartProvider mounts → useEffect runs
4. API called: `GET /api/cart/listings?ids=abc123,def456`
5. **IF** API returns `[]` (empty array):
   - Log warning
   - Return early (don't update cart)
   - **Cart persists** ✅

6. **IF** API returns valid listings:
   - Validate each item
   - Update cart with fresh data
   - Remove invalid items if needed

## Why This Fix is Safe

### Scenario 1: Backend Not Ready
- API returns 404/500 → caught by `if (error)` ✅
- API returns `[]` → caught by new check ✅
- Cart persists until backend is ready

### Scenario 2: Backend Returns Empty (Bug)
- API returns `[]` when it should return data
- Cart persists instead of being cleared
- User can still see/use cart
- Once backend is fixed, next refresh will update cart

### Scenario 3: Listing Actually Deleted
- API returns other listings, but not deleted one
- `validateCartItem()` detects missing listing
- Only that specific item is removed
- Other items remain in cart ✅

### Scenario 4: All Listings Deleted (Rare)
- API returns `[]` legitimately
- Cart persists (potentially stale data)
- **Trade-off:** Better to show stale cart than clear working cart
- User can manually clear cart or remove items

## Testing

**Before Fix:**
1. Add item to cart
2. Refresh page
3. Cart is empty ❌

**After Fix:**
1. Add item to cart
2. Refresh page (with backend not ready)
3. Cart persists ✅
4. Console shows: "Cart refresh returned no listings, keeping existing cart"

**With Backend Ready:**
1. Add item to cart
2. Refresh page (with backend returning data)
3. Cart refreshes with latest data ✅
4. Invalid items removed, valid items updated

## Files Changed

- `client/src/providers/CartProvider.tsx`

Added 6 lines of defensive code to prevent cart clearing on empty API response.